### PR TITLE
http: check rpcallowip immediately after accepting connection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,7 @@ jobs:
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
         with:
-          provider: ${{ needs.runners.outputs.provider }}
+          provider: ${{ github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha' }}
 
       - name: CI script
         run: ./ci/test_run_all.sh
@@ -540,7 +540,7 @@ jobs:
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
         with:
-          provider: ${{ matrix.provider || needs.runners.outputs.provider }}
+          provider: ${{ matrix.provider || (github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha') }}
 
       - name: Clear unnecessary files
         if: ${{ github.repository != 'bitcoin/bitcoin' || matrix.provider == 'gha' }} # Only needed on GHA runners
@@ -584,7 +584,7 @@ jobs:
       - name: Configure Docker
         uses: ./.github/actions/configure-docker
         with:
-          provider: ${{ needs.runners.outputs.provider }}
+          provider: ${{ github.repository == 'bitcoin/bitcoin' && 'warp' || 'gha' }}
 
       - name: CI script
         run: |

--- a/doc/external-signer.md
+++ b/doc/external-signer.md
@@ -67,7 +67,7 @@ Replace `<address>` with the result of `getnewaddress`.
 Under the hood this uses a [PSBT (Partially Signed Bitcoin Transaction)](psbt.md).
 
 ```sh
-bitcoin-cli -rpcwallet=<walletname> sendtoaddress <address> <amount>
+bitcoin rpc -rpcwallet=<walletname> send outputs='{"<address>": <amount>}'
 ```
 
 This constructs a PSBT and prompts your external signer to sign (will fail if it's not connected). If successful, Bitcoin Core finalizes and broadcasts the transaction.
@@ -218,6 +218,4 @@ It then imports descriptors for all supported address types, in a BIP44/49/84/86
 
 The `walletdisplayaddress` RPC reuses some code from `getaddressinfo` on the provided address and obtains the inferred descriptor. It then calls `<cmd> --fingerprint=00000000 displayaddress --desc=<descriptor>`.
 
-For external-signer wallets, spending uses `send` or `sendall`. Bitcoin Core builds a PSBT, calls the signer via stdin with `signtx`, and if signatures are sufficient, finalizes and broadcasts the transaction. If the signer is not connected or cancels, the call fails with an error. For fee-bumping on such wallets, use `psbtbumpfee` to involve an external signer.
-
-`sendtoaddress` and `sendmany` check `inputs->bip32_derivs` to see if any inputs have the same `master_fingerprint` as the signer. If so, it calls `<cmd> --fingerprint=00000000 signtransaction <psbt>`. It waits for the device to return a (partially) signed psbt, tries to finalize it and broadcasts the transaction.
+For external-signer wallets, spending uses `send` or `sendall`, and fee-bumping uses `bumpfee`. Bitcoin Core builds a PSBT, adds key origin information, checks whether any input key origin fingerprint matches the signer, calls `<cmd> --stdin --fingerprint 00000000 --chain <name>`, and sends `signtx <psbt>` over stdin. If signatures are sufficient, it finalizes the transaction and, for broadcasting RPCs, broadcasts it. If signing cannot complete, the call fails with an error. For manual fee-bumping, use `psbtbumpfee` to obtain a PSBT for signing.

--- a/doc/external-signer.md
+++ b/doc/external-signer.md
@@ -125,12 +125,14 @@ Usage:
 [
     {
         "fingerprint": "00000000",
-        "name": "trezor_t"
+        "model": "trezor_t"
     }
 ]
 ```
 
 The command MUST return an array, possibly empty, of entries that contain at least a `fingerprint` field.
+
+If present, the optional `model` field is used as the device name in the `enumeratesigners` RPC result.
 
 A future extension could add an optional return field with device capabilities. Perhaps a descriptor with wildcards. For example: `["pkh("44'/0'/$'/{0,1}/*"), sh(wpkh("49'/0'/$'/{0,1}/*")), wpkh("84'/0'/$'/{0,1}/*")]`. This would indicate the device supports legacy, wrapped SegWit and native SegWit. In addition it restricts the derivation paths that can used for those, to maintain compatibility with other wallet software. It also indicates the device, or the driver, doesn't support multisig.
 
@@ -204,7 +206,9 @@ The command MAY complain if `--chain` is set to a test-network, but the BIP32 co
 
 ## How Bitcoin Core uses the Signer API
 
-The `enumeratesigners` RPC simply calls `<cmd> enumerate`.
+The `enumeratesigners` RPC calls `<cmd> enumerate`, skips duplicate entries with the same `fingerprint`, and maps the optional `model` field to the RPC `name` field.
+
+Wallet operations that need a signer (`createwallet`, `walletdisplayaddress` and spending) also call `<cmd> enumerate` and fail unless exactly one signer is found, so only one device should be connected at a time.
 
 The `createwallet` RPC calls:
 

--- a/doc/external-signer.md
+++ b/doc/external-signer.md
@@ -84,13 +84,17 @@ Prerequisite knowledge:
 * [Output Descriptors](descriptors.md)
 * Partially Signed Bitcoin Transaction ([PSBT](psbt.md))
 
-### Flag `--chain <name>` (required)
+### Flag `--chain <name>` (required except for `enumerate`)
 
 With `<name>` one of `main`, `test`, `signet`, `regtest`, `testnet4`.
 
+Bitcoin Core passes this flag to commands that operate on a chain-specific signer, for example `getdescriptors`, `displayaddress` and `signtx`.
+
 ### Flag `--stdin` (required)
 
-Indicate that (sub)command should be received over stdin and results returned in response to that. `--stdin` is a global flag, it is not used for all subcommands.
+Indicate that (sub)command should be received over stdin and results returned in response to that. `--stdin` is a global flag, it is not specific to any subcommand.
+
+Bitcoin Core currently uses this flag for `signtx`.
 
 All subcommands SHOULD support both
 - being called as commandline arguments; or
@@ -107,11 +111,11 @@ Usage:
 
 Note: remember that shell-expansion is not available on _stdin_. Consequently, commands such as `signtx`, may write their arguments in either quoted or unquoted form.
 
-### Flag `--fingerprint <fingerprint>` (required)
+### Flag `--fingerprint <fingerprint>` (required except for `enumerate`)
 
 With `<fingerprint>` being the hexadecimal 8-symbol identifier for a wallet.
 
-Commands will specify a fingerprint as an identifier for external-signer wallet.
+Bitcoin Core passes this flag to commands that operate on a specific external-signer wallet, for example `getdescriptors`, `displayaddress` and `signtx`.
 
 ### `enumerate` (required)
 
@@ -155,14 +159,13 @@ The command MAY complain if `--chain` is set to a test-network, but any of the B
 Usage:
 
 ```sh
-<cmd> --fingerprint=<fingerprint> getdescriptors <account>
-<xpub>
+<cmd> --fingerprint <fingerprint> --chain <name> getdescriptors --account <account>
 ```
 
 Returns descriptors supported by the device. Example:
 
 ```sh
-<cmd> --fingerprint=00000000 getdescriptors
+<cmd> --fingerprint 00000000 --chain main getdescriptors --account 0
 ```
 
 ```
@@ -184,13 +187,13 @@ Returns descriptors supported by the device. Example:
 
 Usage:
 ```sh
-<cmd> --fingerprint=<fingerprint> displayaddress --desc <descriptor>
+<cmd> --fingerprint <fingerprint> --chain <name> displayaddress --desc <descriptor>
 ```
 
 Example, display the first native SegWit receive address on Testnet:
 
 ```sh
-<cmd> --chain test --fingerprint=00000000 displayaddress --desc "wpkh([00000000/84h/1h/0h]tpubDDUZ..../0/0)"
+<cmd> --fingerprint 00000000 --chain test displayaddress --desc "wpkh([00000000/84h/1h/0h]tpubDDUZ..../0/0)"
 ```
 
 The command MUST be able to figure out the address type from the descriptor.
@@ -212,10 +215,10 @@ Wallet operations that need a signer (`createwallet`, `walletdisplayaddress` and
 
 The `createwallet` RPC calls:
 
-* `<cmd> --chain <name> --fingerprint=00000000 getdescriptors --account 0`
+* `<cmd> --fingerprint 00000000 --chain <name> getdescriptors --account 0`
 
 It then imports descriptors for all supported address types, in a BIP44/49/84/86 compatible manner.
 
-The `walletdisplayaddress` RPC reuses some code from `getaddressinfo` on the provided address and obtains the inferred descriptor. It then calls `<cmd> --fingerprint=00000000 displayaddress --desc=<descriptor>`.
+The `walletdisplayaddress` RPC obtains the inferred descriptor for the provided address. It then calls `<cmd> --fingerprint 00000000 --chain <name> displayaddress --desc <descriptor>`.
 
 For external-signer wallets, spending uses `send` or `sendall`, and fee-bumping uses `bumpfee`. Bitcoin Core builds a PSBT, adds key origin information, checks whether any input key origin fingerprint matches the signer, calls `<cmd> --stdin --fingerprint 00000000 --chain <name>`, and sends `signtx <psbt>` over stdin. If signatures are sufficient, it finalizes the transaction and, for broadcasting RPCs, broadcasts it. If signing cannot complete, the call fails with an error. For manual fee-bumping, use `psbtbumpfee` to obtain a PSBT for signing.

--- a/doc/external-signer.md
+++ b/doc/external-signer.md
@@ -173,12 +173,14 @@ Returns descriptors supported by the device. Example:
   "receive": [
     "pkh([00000000/44h/0h/0h]xpub6C.../0/*)#fn95jwmg",
     "sh(wpkh([00000000/49h/0h/0h]xpub6B..../0/*))#j4r9hntt",
-    "wpkh([00000000/84h/0h/0h]xpub6C.../0/*)#qw72dxa9"
+    "wpkh([00000000/84h/0h/0h]xpub6C.../0/*)#qw72dxa9",
+    "tr([00000000/86h/0h/0h]xpub6C.../0/*)#4d8tq2ns"
   ],
   "internal": [
     "pkh([00000000/44h/0h/0h]xpub6C.../1/*)#c8q40mts",
     "sh(wpkh([00000000/49h/0h/0h]xpub6B..../1/*))#85dn0v75",
-    "wpkh([00000000/84h/0h/0h]xpub6C..../1/*)#36mtsnda"
+    "wpkh([00000000/84h/0h/0h]xpub6C..../1/*)#36mtsnda",
+    "tr([00000000/86h/0h/0h]xpub6C.../1/*)#d63h6jpt"
   ]
 }
 ```

--- a/src/external_signer.h
+++ b/src/external_signer.h
@@ -58,7 +58,8 @@ public:
     UniValue GetDescriptors(int account);
 
     //! Sign PartiallySignedTransaction on the device.
-    //! Calls `<command> signtransaction` and passes the PSBT via stdin.
+    //! Calls `<command> --stdin --fingerprint <fingerprint> --chain <chain>` and passes the
+    //! `signtx` command and PSBT via stdin.
     //! @param[in,out] psbt  PartiallySignedTransaction to be signed
     bool SignTransaction(PartiallySignedTransaction& psbt, std::string& error);
 };

--- a/src/external_signer.h
+++ b/src/external_signer.h
@@ -29,7 +29,7 @@ private:
 public:
     //! @param[in] command      the command which handles interaction with the external signer
     //! @param[in] fingerprint  master key fingerprint of the signer
-    //! @param[in] chain        "main", "test", "regtest" or "signet"
+    //! @param[in] chain        "main", "test", "signet", "regtest" or "testnet4"
     //! @param[in] name         device name
     ExternalSigner(std::vector<std::string> command, std::string chain, std::string fingerprint, std::string name);
 
@@ -42,17 +42,19 @@ public:
     //! Obtain a list of signers. Calls `<command> enumerate`.
     //! @param[in]              command the command which handles interaction with the external signer
     //! @param[in,out] signers  vector to which new signers (with a unique master key fingerprint) are added
-    //! @param chain            "main", "test", "regtest" or "signet"
+    //! @param chain            "main", "test", "signet", "regtest" or "testnet4"
     //! @returns success
     static bool Enumerate(const std::string& command, std::vector<ExternalSigner>& signers, const std::string& chain);
 
-    //! Display address on the device. Calls `<command> displayaddress --desc <descriptor>`.
+    //! Display address on the device. Calls `<command> --fingerprint <fingerprint> --chain <chain>
+    //! displayaddress --desc <descriptor>`.
     //! @param[in] descriptor Descriptor specifying which address to display.
     //!            Must include a public key or xpub, as well as key origin.
     UniValue DisplayAddress(const std::string& descriptor) const;
 
     //! Get receive and change Descriptor(s) from device for a given account.
-    //! Calls `<command> getdescriptors --account <account>`
+    //! Calls `<command> --fingerprint <fingerprint> --chain <chain> getdescriptors
+    //! --account <account>`.
     //! @param[in] account  which BIP32 account to use (e.g. `m/44'/0'/account'`)
     //! @returns see doc/external-signer.md
     UniValue GetDescriptors(int account);

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -67,8 +67,6 @@ struct HTTPPathHandler
 /** HTTP module state */
 
 static std::unique_ptr<http_bitcoin::HTTPServer> g_http_server{nullptr};
-//! List of subnets to allow RPC connections from
-static std::vector<CSubNet> rpc_allow_subnets;
 //! Handlers for (sub)paths
 static GlobalMutex g_httppathhandlers_mutex;
 static std::vector<HTTPPathHandler> pathHandlers GUARDED_BY(g_httppathhandlers_mutex);
@@ -77,23 +75,24 @@ static std::vector<HTTPPathHandler> pathHandlers GUARDED_BY(g_httppathhandlers_m
 static ThreadPool g_threadpool_http("http");
 static int g_max_queue_depth{100};
 
+namespace http_bitcoin {
 /** Check if a network address is allowed to access the HTTP server */
-static bool ClientAllowed(const CNetAddr& netaddr)
+bool HTTPServer::ClientAllowed(const CNetAddr& netaddr)
 {
     if (!netaddr.IsValid())
         return false;
-    for(const CSubNet& subnet : rpc_allow_subnets)
+    for(const CSubNet& subnet : m_allow_subnets)
         if (subnet.Match(netaddr))
             return true;
     return false;
 }
 
 /** Initialize ACL list for HTTP server */
-static bool InitHTTPAllowList()
+bool HTTPServer::InitHTTPAllowList()
 {
-    rpc_allow_subnets.clear();
-    rpc_allow_subnets.emplace_back(LookupHost("127.0.0.1", false).value(), 8);  // always allow IPv4 local subnet
-    rpc_allow_subnets.emplace_back(LookupHost("::1", false).value());  // always allow IPv6 localhost
+    m_allow_subnets.clear();
+    m_allow_subnets.emplace_back(LookupHost("127.0.0.1", false).value(), 8);  // always allow IPv4 local subnet
+    m_allow_subnets.emplace_back(LookupHost("::1", false).value());  // always allow IPv6 localhost
     for (const std::string& strAllow : gArgs.GetArgs("-rpcallowip")) {
         const CSubNet subnet{LookupSubNet(strAllow)};
         if (!subnet.IsValid()) {
@@ -102,14 +101,15 @@ static bool InitHTTPAllowList()
                 CClientUIInterface::MSG_ERROR);
             return false;
         }
-        rpc_allow_subnets.push_back(subnet);
+        m_allow_subnets.push_back(subnet);
     }
     std::string strAllowed;
-    for (const CSubNet& subnet : rpc_allow_subnets)
+    for (const CSubNet& subnet : m_allow_subnets)
         strAllowed += subnet.ToString() + " ";
     LogDebug(BCLog::HTTP, "Allowing HTTP connections from: %s\n", strAllowed);
     return true;
 }
+} // namespace http_bitcoin
 
 /** HTTP request method as string - use for logging only */
 std::string_view RequestMethodString(HTTPRequestMethod m)
@@ -127,14 +127,6 @@ std::string_view RequestMethodString(HTTPRequestMethod m)
 
 static void MaybeDispatchRequestToWorker(std::shared_ptr<HTTPRequest> hreq)
 {
-    // Early address-based allow check
-    if (!ClientAllowed(hreq->GetPeer())) {
-        LogDebug(BCLog::HTTP, "HTTP request from %s rejected: Client network is not allowed RPC access\n",
-                 hreq->GetPeer().ToStringAddrPort());
-        hreq->WriteReply(HTTP_FORBIDDEN);
-        return;
-    }
-
     // Early reject unknown HTTP methods
     if (hreq->GetRequestMethod() == HTTPRequestMethod::UNKNOWN) {
         LogDebug(BCLog::HTTP, "HTTP request from %s rejected: Unknown HTTP request method\n",
@@ -793,6 +785,14 @@ std::unique_ptr<Sock> HTTPServer::AcceptConnection(const Sock& listen_sock, CSer
                  "Unknown socket family");
     }
 
+    // Early address-based allow check
+    if (!ClientAllowed(addr)) {
+        LogDebug(BCLog::HTTP, "HTTP request from %s rejected: Client network is not allowed RPC access\n",
+                 addr.ToStringAddrPort());
+        // Socket destroyed, connection aborted
+        return {};
+    }
+
     return sock;
 }
 
@@ -1201,12 +1201,12 @@ bool HTTPRemoteClient::MaybeSendBytesFromBuffer()
 
 bool InitHTTPServer()
 {
-    if (!InitHTTPAllowList()) {
-        return false;
-    }
-
     // Create HTTPServer
     g_http_server = std::make_unique<HTTPServer>(MaybeDispatchRequestToWorker);
+
+    if (!g_http_server->InitHTTPAllowList()) {
+        return false;
+    }
 
     g_http_server->SetServerTimeout(std::chrono::seconds(gArgs.GetIntArg("-rpcservertimeout", DEFAULT_HTTP_SERVER_TIMEOUT)));
 

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -216,6 +216,11 @@ public:
     }
 
     /**
+     * Parse the user's -rpcallowip settings and populate m_allow_subnets
+     */
+    bool InitHTTPAllowList();
+
+    /**
      * Bind to a new address:port, start listening and add the listen socket to `m_listen`.
      * @param[in] to Where to bind.
      * @returns {} or the reason for failure.
@@ -375,6 +380,16 @@ private:
      * Idle timeout after which clients are disconnected
      */
     std::chrono::seconds m_rpcservertimeout{DEFAULT_HTTP_SERVER_TIMEOUT};
+
+    /**
+     * List of subnets to allow HTTP connections from
+     */
+    std::vector<CSubNet> m_allow_subnets;
+
+    /**
+     * Check an incoming connection's source IP against the allow list
+     */
+    bool ClientAllowed(const CNetAddr& netaddr);
 
     /**
      * Accept a connection.

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -255,6 +255,18 @@ CBlockIndex* BlockManager::AddToBlockIndex(const CBlockHeader& block, CBlockInde
     return pindexNew;
 }
 
+void BlockManager::AddUnlinkedBlock(CBlockIndex* block)
+{
+    AssertLockHeld(cs_main);
+    Assume(block != nullptr);
+    Assume(block->nStatus & BLOCK_HAVE_DATA);
+    auto range = m_blocks_unlinked.equal_range(block->pprev);
+    for (auto it = range.first; it != range.second; ++it) {
+        if (it->second == block) return;  // don't insert duplicates
+    }
+    m_blocks_unlinked.emplace(block->pprev, block);
+}
+
 void BlockManager::PruneOneBlockFile(const int fileNumber)
 {
     AssertLockHeld(cs_main);
@@ -487,7 +499,7 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
                 } else {
                     pindex->m_chain_tx_count = 0;
                     if (pindex->nStatus & BLOCK_HAVE_DATA) {
-                        m_blocks_unlinked.insert(std::make_pair(pindex->pprev, pindex));
+                        AddUnlinkedBlock(pindex);
                     }
                 }
             } else {

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -354,6 +354,7 @@ public:
      * All pairs A->B, where A (or one of its ancestors) misses transactions, but B has transactions.
      */
     std::multimap<CBlockIndex*, CBlockIndex*> m_blocks_unlinked;
+    void AddUnlinkedBlock(CBlockIndex* block) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     std::unique_ptr<BlockTreeDB> m_block_tree_db GUARDED_BY(::cs_main);
 

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -352,7 +352,6 @@ public:
 
     /**
      * All pairs A->B, where A (or one of its ancestors) misses transactions, but B has transactions.
-     * Pruned nodes may have entries where B is missing data.
      */
     std::multimap<CBlockIndex*, CBlockIndex*> m_blocks_unlinked;
 

--- a/src/rpc/external_signer.cpp
+++ b/src/rpc/external_signer.cpp
@@ -20,7 +20,7 @@
 static RPCMethod enumeratesigners()
 {
     return RPCMethod{"enumeratesigners",
-        "Returns a list of external signers from -signer.",
+        "Returns a list of external signers from -signer. Signers with duplicate master key fingerprints are skipped.",
         {},
         RPCResult{
             RPCResult::Type::OBJ, "", "",
@@ -30,7 +30,7 @@ static RPCMethod enumeratesigners()
                     {RPCResult::Type::OBJ, "", "",
                     {
                         {RPCResult::Type::STR_HEX, "fingerprint", "Master key fingerprint"},
-                        {RPCResult::Type::STR, "name", "Device name"},
+                        {RPCResult::Type::STR, "name", "Device name, the model returned by the signer"},
                     }},
                 },
                 }

--- a/src/test/fuzz/dbwrapper.cpp
+++ b/src/test/fuzz/dbwrapper.cpp
@@ -30,6 +30,7 @@
 #include <numeric>
 #include <optional>
 #include <set>
+#include <span>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -168,6 +169,9 @@ void VerifyIterator(CDBWrapper& dbw, const Oracle& oracle,
 
 /** Maximum number of concurrent reader threads in dbwrapper_concurrent_reads. */
 constexpr size_t MAX_READ_WORKERS{8};
+
+/** Maximum number of queries each worker executes in dbwrapper_concurrent_reads. */
+constexpr size_t MAX_READ_QUERIES_PER_WORKER{128};
 
 ThreadPool g_read_pool{"dbfuzz"};
 Mutex g_read_pool_mutex;
@@ -371,7 +375,7 @@ FUZZ_TARGET(dbwrapper_concurrent_reads, .init = [] { static auto setup{MakeNoLog
 
     // Seed the DB. Drain work after small batches so we don't deadlock on a
     // scheduled compaction.
-    const size_t num_entries{provider.ConsumeIntegralInRange<size_t>(100, 3'000)};
+    const size_t num_entries{provider.ConsumeIntegralInRange<size_t>(100, 5'000)};
     std::vector<uint16_t> keys;
     keys.reserve(num_entries);
     Oracle oracle;
@@ -416,12 +420,13 @@ FUZZ_TARGET(dbwrapper_concurrent_reads, .init = [] { static auto setup{MakeNoLog
             std::vector<size_t> order(queries.size());
             std::iota(order.begin(), order.end(), size_t{0});
             std::ranges::shuffle(order, thread_rng);
+            const size_t queries_to_run{std::min(queries.size(), MAX_READ_QUERIES_PER_WORKER)};
             std::vector<uint8_t> v;
             std::string key_str;
             start_latch.arrive_and_wait();
             const std::unique_ptr<CDBIterator> it{db.NewIterator()};
             // Every read must agree with the oracle, the source of truth.
-            for (const auto i : order) {
+            for (const auto i : std::span{order}.first(queries_to_run)) {
                 const auto& [op, key] = queries[i];
                 switch (op) {
                 case ReadOp::Read:

--- a/src/test/fuzz/dbwrapper.cpp
+++ b/src/test/fuzz/dbwrapper.cpp
@@ -174,11 +174,9 @@ constexpr size_t MAX_READ_WORKERS{8};
 constexpr size_t MAX_READ_QUERIES_PER_WORKER{128};
 
 ThreadPool g_read_pool{"dbfuzz"};
-Mutex g_read_pool_mutex;
 
-void StartReadPoolIfNeeded() EXCLUSIVE_LOCKS_REQUIRED(!g_read_pool_mutex)
+void StartReadPoolIfNeeded()
 {
-    LOCK(g_read_pool_mutex);
     if (!g_read_pool.WorkersCount()) g_read_pool.Start(MAX_READ_WORKERS);
 }
 
@@ -361,7 +359,7 @@ FUZZ_TARGET(dbwrapper_threaded, .init = [] { static auto setup{MakeNoLogFileCont
         /*allow_force_compact=*/true);
 }
 
-FUZZ_TARGET(dbwrapper_concurrent_reads, .init = [] { static auto setup{MakeNoLogFileContext<>()}; }) EXCLUSIVE_LOCKS_REQUIRED(!g_read_pool_mutex)
+FUZZ_TARGET(dbwrapper_concurrent_reads, .init = [] { static auto setup{MakeNoLogFileContext<>()}; })
 {
     StartReadPoolIfNeeded();
     SeedRandomStateForTest(SeedRand::ZEROS);

--- a/src/test/fuzz/threadpool.cpp
+++ b/src/test/fuzz/threadpool.cpp
@@ -43,13 +43,11 @@ static void GetFuture(std::future<void>& future, uint32_t& fail_counter)
 // instability in the fuzzing environment.
 // This is also how we use it in the app's lifecycle.
 ThreadPool g_pool{"fuzz"};
-Mutex g_pool_mutex;
 // Global to verify we always have the same number of threads.
 size_t g_num_workers = 3;
 
-static void StartPoolIfNeeded() EXCLUSIVE_LOCKS_REQUIRED(!g_pool_mutex)
+static void StartPoolIfNeeded()
 {
-    LOCK(g_pool_mutex);
     if (g_pool.WorkersCount() == g_num_workers) return;
     g_pool.Start(g_num_workers);
 }
@@ -60,7 +58,7 @@ static void setup_threadpool_test()
     LogInstance().DisableLogging();
 }
 
-FUZZ_TARGET(threadpool, .init = setup_threadpool_test) EXCLUSIVE_LOCKS_REQUIRED(!g_pool_mutex)
+FUZZ_TARGET(threadpool, .init = setup_threadpool_test)
 {
     // Because LibAFL calls fork() after calling the init setup function,
     // the child processes end up having one thread active and no workers.

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -520,6 +520,7 @@ BOOST_AUTO_TEST_CASE(http_server_socket_tests)
     };
 
     HTTPServer server{StoreRequest};
+    server.InitHTTPAllowList();
 
     {
         // We can only bind to NET_IPV4 and NET_IPV6

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -640,6 +640,10 @@ std::vector<CTransactionRef> TestChain100Setup::PopulateMempool(FastRandomContex
 
 SocketTestingSetup::SocketTestingSetup()
 {
+    // HTTPServer is not integrated into NodeContext yet and still pulls global args.
+    // This is the IP address DynSock claims to be from when connecting.
+    gArgs.ForceSetArg("-rpcallowip", "5.5.5.5");
+
     // "back up" the current CreateSock() so we can restore it after the test
     m_create_sock_orig = CreateSock;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3141,12 +3141,18 @@ CBlockIndex* Chainstate::FindMostWorkChain()
                 }
                 // Remove the entire chain from the set.
                 for (CBlockIndex *pindexFailed = pindexNew; pindexFailed != pindexTest; pindexFailed = pindexFailed->pprev) {
+                    // If we're missing data and not a descendant of an invalid block,
+                    // then add back to m_blocks_unlinked, so that if the block arrives in the future
+                    // we can try adding to setBlockIndexCandidates again.
                     if (fMissingData && !fFailedChain) {
-                        // If we're missing data and not a descendant of an invalid block,
-                        // then add back to m_blocks_unlinked, so that if the block arrives in the future
-                        // we can try adding to setBlockIndexCandidates again.
-                        m_blockman.m_blocks_unlinked.insert(
-                            std::make_pair(pindexFailed->pprev, pindexFailed));
+                        // Avoid duplicate entries in m_blocks_unlinked. If the same entry is
+                        // processed twice in ReceivedBlockTransactions(), it may be re-added to
+                        // setBlockIndexCandidates with a modified nSequenceId, breaking ordering
+                        // guarantees and leading to undefined behavior.
+                        auto range = m_blockman.m_blocks_unlinked.equal_range(pindexFailed->pprev);
+                        if (!std::any_of(range.first, range.second, [&](const auto& p) { return p.second == pindexFailed; })) {
+                            m_blockman.m_blocks_unlinked.emplace(pindexFailed->pprev, pindexFailed);
+                        }
                     }
                     setBlockIndexCandidates.erase(pindexFailed);
                 }
@@ -5340,13 +5346,12 @@ void ChainstateManager::CheckBlockIndex() const
         // Check whether this block is in m_blocks_unlinked.
         auto rangeUnlinked{m_blockman.m_blocks_unlinked.equal_range(pindex->pprev)};
         bool foundInUnlinked = false;
-        while (rangeUnlinked.first != rangeUnlinked.second) {
-            assert(rangeUnlinked.first->first == pindex->pprev);
-            if (rangeUnlinked.first->second == pindex) {
+        for (auto it = rangeUnlinked.first; it != rangeUnlinked.second; ++it) {
+            assert(it->first == pindex->pprev);
+            if (it->second == pindex) {
+                assert(!foundInUnlinked); // No duplicates in m_blocks_unlinked
                 foundInUnlinked = true;
-                break;
             }
-            rangeUnlinked.first++;
         }
         if (pindex->pprev && (pindex->nStatus & BLOCK_HAVE_DATA) && pindexFirstNeverProcessed != nullptr && pindexFirstInvalid == nullptr) {
             // If this block has block data available, some parent was never received, and has no invalid parents, it must be in m_blocks_unlinked.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3149,10 +3149,7 @@ CBlockIndex* Chainstate::FindMostWorkChain()
                         // processed twice in ReceivedBlockTransactions(), it may be re-added to
                         // setBlockIndexCandidates with a modified nSequenceId, breaking ordering
                         // guarantees and leading to undefined behavior.
-                        auto range = m_blockman.m_blocks_unlinked.equal_range(pindexFailed->pprev);
-                        if (!std::any_of(range.first, range.second, [&](const auto& p) { return p.second == pindexFailed; })) {
-                            m_blockman.m_blocks_unlinked.emplace(pindexFailed->pprev, pindexFailed);
-                        }
+                        m_blockman.AddUnlinkedBlock(pindexFailed);
                     }
                     setBlockIndexCandidates.erase(pindexFailed);
                 }
@@ -3816,7 +3813,7 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
         }
     } else {
         if (pindexNew->pprev && pindexNew->pprev->IsValid(BLOCK_VALID_TREE)) {
-            m_blockman.m_blocks_unlinked.insert(std::make_pair(pindexNew->pprev, pindexNew));
+            m_blockman.AddUnlinkedBlock(pindexNew);
         }
     }
 }

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -173,7 +173,11 @@ UniValue SendMoney(CWallet& wallet, const CCoinControl &coin_control, std::vecto
     EnsureWalletIsUnlocked(wallet);
 
     // This function is only used by sendtoaddress and sendmany.
-    // This should always try to sign, if we don't have private keys, don't try to do anything here.
+    // This should always try to sign, if we don't have (all) private keys, don't
+    // try to do anything here.
+    if (wallet.IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER)) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Error: sendtoaddress and sendmany are not supported for wallets with external signers; use send instead");
+    }
     if (wallet.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Error: Private keys are disabled for this wallet");
     }

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -236,8 +236,8 @@ class PruneTest(BitcoinTestFramework):
         self.nodes[2].getblock(self.nodes[2].getblockhash(self.forkheight))
 
         first_reorg_height = self.nodes[2].getblockcount()
-        curchainhash = self.nodes[2].getblockhash(self.mainchainheight)
-        self.nodes[2].invalidateblock(curchainhash)
+        block_hash_1295 = self.nodes[2].getblockhash(1295)
+        self.nodes[2].invalidateblock(block_hash_1295)
         goalbestheight = self.mainchainheight
         goalbesthash = self.mainchainhash2
 
@@ -252,7 +252,7 @@ class PruneTest(BitcoinTestFramework):
         if self.nodes[2].getblockcount() < self.mainchainheight:
             blocks_to_mine = first_reorg_height + 1 - self.mainchainheight
             self.log.info(f"Rewind node 0 to prev main chain to mine longer chain to trigger redownload. Blocks needed: {blocks_to_mine}")
-            self.nodes[0].invalidateblock(curchainhash)
+            self.nodes[0].invalidateblock(block_hash_1295)
             assert_equal(self.nodes[0].getblockcount(), self.mainchainheight)
             assert_equal(self.nodes[0].getbestblockhash(), self.mainchainhash2)
             goalbesthash = self.generate(self.nodes[0], blocks_to_mine, sync_fun=self.no_op)[-1]

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -6,7 +6,6 @@
 
 WARNING:
 This test uses 4GB of disk space.
-This test takes 30 mins or more (up to 2 hours)
 """
 import os
 
@@ -351,17 +350,15 @@ class PruneTest(BitcoinTestFramework):
         self.log.info("Stop and start pruning node to trigger wallet rescan")
         self.restart_node(2, extra_args=["-prune=550"])
 
-        wallet_info = self.nodes[2].getwalletinfo()
-        self.wait_until(lambda: wallet_info["scanning"] == False)
-        self.wait_until(lambda: wallet_info["lastprocessedblock"]["height"] == self.nodes[2].getblockcount())
+        self.wait_until(lambda: self.nodes[2].getwalletinfo()["scanning"] == False)
+        self.wait_until(lambda: self.nodes[2].getwalletinfo()["lastprocessedblock"]["height"] == self.nodes[2].getblockcount())
 
         # check that wallet loads successfully when restarting a pruned node after IBD.
         # this was reported to fail in #7494.
         self.restart_node(5, extra_args=["-prune=550", "-blockfilterindex=1"]) # restart to trigger rescan
 
-        wallet_info = self.nodes[5].getwalletinfo()
-        self.wait_until(lambda: wallet_info["scanning"] == False)
-        self.wait_until(lambda: wallet_info["lastprocessedblock"]["height"] == self.nodes[0].getblockcount())
+        self.wait_until(lambda: self.nodes[5].getwalletinfo()["scanning"] == False)
+        self.wait_until(lambda: self.nodes[5].getwalletinfo()["lastprocessedblock"]["height"] == self.nodes[0].getblockcount())
 
     def run_test(self):
         self.log.info("Warning! This test requires 4GB of disk space")

--- a/test/functional/interface_http.py
+++ b/test/functional/interface_http.py
@@ -5,6 +5,7 @@
 """Test the HTTP server basics."""
 
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.netutil import NETWORK_ERRORS
 from test_framework.util import assert_equal, str_to_b64str
 
 import http.client
@@ -16,15 +17,6 @@ RPCSERVERTIMEOUT = 2
 # Set in httpserver.h
 MAX_HEADERS_SIZE = 8192
 MAX_BODY_SIZE = 32 * 1024 * 1024
-
-# When a test expects a server disconnection, any of these errors are
-# acceptable. The specific event is determined by race condition and platform OS.
-NETWORK_ERRORS = (
-    BrokenPipeError,                 # write to a closed socket/pipe
-    ConnectionResetError,            # connection forcibly closed by peer
-    ConnectionAbortedError,          # connection aborted locally or by network stack
-    http.client.ResponseNotReady,    # server response not ready or connection out of sync
-)
 
 class BitcoinHTTPConnection:
     def __init__(self, node):

--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -7,7 +7,8 @@
 from test_framework.netutil import all_interfaces, addr_to_hex, get_bind_addrs, test_ipv6_local
 from test_framework.test_framework import BitcoinTestFramework, SkipTest
 from test_framework.test_node import ErrorMatch
-from test_framework.util import assert_equal, assert_raises_rpc_error, rpc_port
+from test_framework.netutil import NETWORK_ERRORS
+from test_framework.util import assert_equal, rpc_port
 
 class RPCBindTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -62,6 +63,7 @@ class RPCBindTest(BitcoinTestFramework):
         Start a node with rpcallow IP, and request getnetworkinfo
         at a non-localhost IP.
         '''
+        success = True
         self.log.info("Allow IP test for %s:%d" % (rpchost, rpcport))
         node_args = \
             ['-disablewallet', '-nolisten'] + \
@@ -72,8 +74,12 @@ class RPCBindTest(BitcoinTestFramework):
         self.nodes[0].rpchost = f"{rpchost}:{rpcport}"
         # connect to node through non-loopback interface
         node = self.nodes[0].create_new_rpc_connection()
-        node.getnetworkinfo()
+        try:
+            node.getnetworkinfo()
+        except NETWORK_ERRORS:
+            success = False
         self.stop_nodes()
+        return success
 
     def run_invalid_allowip_test(self):
         '''
@@ -162,12 +168,13 @@ class RPCBindTest(BitcoinTestFramework):
         self.run_bind_test([self.non_loopback_ip], self.non_loopback_ip, [self.non_loopback_ip],
             [(self.non_loopback_ip, self.defaultport)])
 
-        # Check that with invalid rpcallowip, we are denied
-        self.run_allowip_test([self.non_loopback_ip], self.non_loopback_ip, self.defaultport)
+        # Check that connections from allowed IPs are allowed
+        assert self.run_allowip_test([self.non_loopback_ip], self.non_loopback_ip, self.defaultport)
+        # Otherwise we are denied
         if self.options.usecli:
             self.log.info("Skip negative IP test with CLI, because the CLI can not throw the tested exception type")
             return
-        assert_raises_rpc_error(-342, "non-JSON HTTP response with '403 Forbidden' from server", self.run_allowip_test, ['1.1.1.1'], self.non_loopback_ip, self.defaultport)
+        assert not self.run_allowip_test(['1.1.1.1'], self.non_loopback_ip, self.defaultport)
 
 if __name__ == '__main__':
     RPCBindTest(__file__).main()

--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -7,6 +7,7 @@
 Roughly based on https://web.archive.org/web/20190424172231/http://voorloopnul.com/blog/a-python-netstat-in-less-than-100-lines-of-code/ by Ricardo Pascal
 """
 
+import http.client
 import sys
 import socket
 import struct
@@ -33,6 +34,15 @@ STATE_LISTEN = '0A'
 ADDRMAN_NEW_BUCKET_COUNT = 1 << 10
 ADDRMAN_TRIED_BUCKET_COUNT = 1 << 8
 ADDRMAN_BUCKET_SIZE = 1 << 6
+
+# When a test expects a server disconnection, any of these errors are
+# acceptable. The specific event is determined by race condition and platform OS.
+NETWORK_ERRORS = (
+    BrokenPipeError,                 # write to a closed socket/pipe
+    ConnectionResetError,            # connection forcibly closed by peer
+    ConnectionAbortedError,          # connection aborted locally or by network stack
+    http.client.ResponseNotReady,    # server response not ready or connection out of sync
+)
 
 def get_socket_inodes(pid):
     '''

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -120,6 +120,21 @@ class WalletSignerTest(BitcoinTestFramework):
             result = hww.walletdisplayaddress(address)
             assert_equal(result, {"address": address})
 
+        assert_raises_rpc_error(
+            -4,
+            "Error: sendtoaddress and sendmany are not supported for wallets with external signers; use send instead",
+            hww.sendtoaddress,
+            self.nodes[0].getnewaddress(),
+            0.01,
+        )
+        assert_raises_rpc_error(
+            -4,
+            "Error: sendtoaddress and sendmany are not supported for wallets with external signers; use send instead",
+            hww.sendmany,
+            "",
+            {self.nodes[0].getnewaddress(): 0.01},
+        )
+
         # Handle error thrown by script
         self.set_mock_result(self.nodes[1], "2")
         assert_raises_rpc_error(-1, 'RunCommandParseJSON error',


### PR DESCRIPTION
Instead of sending 403 Forbidden, disconnect as soon as possible.

To facilitate unit testing, this commit includes a refactor that de-globalizes the subnet allow list, and moves relevant methods inside the HTTP class.
