### PR TITLE
Add state to HTTPRequest

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -983,13 +983,13 @@ void HTTPServer::ThreadSocketHandler()
 
 void HTTPServer::MaybeDispatchRequestsFromClient(const std::shared_ptr<HTTPRemoteClient>& client) const
 {
-    // Try reading (potentially multiple) HTTP requests from the buffer
-    while (!client->m_recv_buffer.empty()) {
+    // Try reading the next HTTP request from the buffer
+    if (!client->m_req) {
         // Create a new request object and try to fill it with data from the receive buffer
         auto req = std::make_unique<HTTPRequest>(client);
         try {
             // Stop reading if we need more data from the client to parse a complete request
-            if (!client->ReadRequest(*req)) break;
+            if (!client->ReadRequest(*req)) return;
         } catch (const ContentTooLargeError& e) {
             LogDebug(
                 BCLog::HTTP,
@@ -1024,8 +1024,8 @@ void HTTPServer::MaybeDispatchRequestsFromClient(const std::shared_ptr<HTTPRemot
             client->m_origin,
             client->m_id);
 
-        // add request to client queue
-        client->m_req_queue.push_back(std::move(req));
+        // Move request to client
+        client->m_req = std::move(req);
     }
 
     // If we are already handling a request from
@@ -1033,12 +1033,11 @@ void HTTPServer::MaybeDispatchRequestsFromClient(const std::shared_ptr<HTTPRemot
     // loop iteration.
     if (client->m_req_busy) return;
 
-    // Otherwise, if there is a pending request in the queue, handle it.
-    if (!client->m_req_queue.empty()) {
+    // Otherwise, if there is a request ready to go, handle it.
+    if (client->m_req) {
         LOCK(m_request_dispatcher_mutex);
         client->m_req_busy = true;
-        m_request_dispatcher(std::move(client->m_req_queue.front()));
-        client->m_req_queue.pop_front();
+        m_request_dispatcher(std::move(client->m_req));
     }
 }
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -426,51 +426,58 @@ bool HTTPRequest::LoadBody(LineReader& reader)
         // Chunked Transfer Coding: https://datatracker.ietf.org/doc/html/rfc7230.html#section-4.1
         // see evhttp_handle_chunked_read() in libevent http.c
         while (reader.Remaining() > 0) {
-            auto maybe_chunk_size = reader.ReadLine();
-            if (!maybe_chunk_size) return false;
+            if (!m_chunk_size) {
+                auto maybe_chunk_size = reader.ReadLine();
+                if (!maybe_chunk_size) return false;
 
-            // Allow (but ignore) Chunk Extensions
-            // See https://www.rfc-editor.org/rfc/rfc9112.html#name-chunk-extensions
-            std::string_view chunk_size_noext{maybe_chunk_size.value()};
-            const auto semicolon_pos = chunk_size_noext.find(';');
-            if (semicolon_pos != chunk_size_noext.npos) {
-                chunk_size_noext.remove_suffix(chunk_size_noext.size() - semicolon_pos);
-            }
-
-            const auto chunk_size{ToIntegral<uint64_t>(util::TrimStringView(chunk_size_noext), /*base=*/16)};
-            if (!chunk_size) throw std::runtime_error("Cannot parse chunk length value");
-
-            if ((m_body.size() > MAX_BODY_SIZE) ||
-                (*chunk_size > MAX_BODY_SIZE - m_body.size()))
-                throw ContentTooLargeError("Chunk will exceed max body size");
-
-            // Last chunk has size 0
-            if (*chunk_size == 0) {
-                // Allow (but ignore) Chunked Trailer section, by
-                // reading CRLF-terminated lines until we read an empty line,
-                // which indicates the end of this request.
-                // See https://httpwg.org/specs/rfc9112.html#rfc.section.7.1.2
-                const size_t trailer_start{reader.Consumed()};
-                while (true) {
-                    auto maybe_trailer = reader.ReadLine();
-                    if (reader.Consumed() - trailer_start > MAX_HEADERS_SIZE) {
-                        throw std::runtime_error("HTTP chunked trailer exceeds size limit");
-                    }
-                    if (!maybe_trailer) return false;
-                    if (maybe_trailer->empty()) break;
+                // Allow (but ignore) Chunk Extensions
+                // See https://www.rfc-editor.org/rfc/rfc9112.html#name-chunk-extensions
+                std::string_view chunk_size_noext{maybe_chunk_size.value()};
+                const auto semicolon_pos = chunk_size_noext.find(';');
+                if (semicolon_pos != chunk_size_noext.npos) {
+                    chunk_size_noext.remove_suffix(chunk_size_noext.size() - semicolon_pos);
                 }
-                // Complete request has been parsed, reader is now pointing
-                // to beginning of next request or end of the buffer.
-                return true;
+
+                m_chunk_size = ToIntegral<uint64_t>(util::TrimStringView(chunk_size_noext), /*base=*/16);
+                if (!m_chunk_size) throw std::runtime_error("Cannot parse chunk length value");
+
+                if ((m_body.size() > MAX_BODY_SIZE) ||
+                    (*m_chunk_size > MAX_BODY_SIZE - m_body.size()))
+                    throw ContentTooLargeError("Chunk will exceed max body size");
+
+                // Last chunk has size 0
+                if (*m_chunk_size == 0) {
+                    // Allow (but ignore) Chunked Trailer section, by
+                    // reading CRLF-terminated lines until we read an empty line,
+                    // which indicates the end of this request.
+                    // See https://httpwg.org/specs/rfc9112.html#rfc.section.7.1.2
+                    const size_t trailer_start{reader.Consumed()};
+                    while (true) {
+                        auto maybe_trailer = reader.ReadLine();
+                        if (reader.Consumed() - trailer_start > MAX_HEADERS_SIZE) {
+                            throw std::runtime_error("HTTP chunked trailer exceeds size limit");
+                        }
+                        if (!maybe_trailer) return false;
+                        if (maybe_trailer->empty()) break;
+                    }
+                    // Complete request has been parsed, reader is now pointing
+                    // to beginning of next request or end of the buffer.
+                    return true;
+                }
             }
+
+            // We either just read the chunk size, or we have it saved
+            // from a prior I/O loop iteration
+            Assume(m_chunk_size);
 
             // We are still expecting more data for this chunk
-            if (reader.Remaining() < *chunk_size) {
+            if (reader.Remaining() < *m_chunk_size) {
                 return false;
             }
 
-            // Pack chunk onto body
-            m_body += reader.ReadLength(*chunk_size);
+            // Pack chunk onto body and clear state
+            m_body += reader.ReadLength(*m_chunk_size);
+            m_chunk_size.reset();
 
             // Even though every chunk size is explicitly declared,
             // they are still terminated by a CRLF we don't need,
@@ -983,49 +990,38 @@ void HTTPServer::ThreadSocketHandler()
 
 void HTTPServer::MaybeDispatchRequestsFromClient(const std::shared_ptr<HTTPRemoteClient>& client) const
 {
-    // Try reading the next HTTP request from the buffer
     if (!client->m_req) {
-        // Create a new request object and try to fill it with data from the receive buffer
-        auto req = std::make_unique<HTTPRequest>(client);
-        try {
-            // Stop reading if we need more data from the client to parse a complete request
-            if (!client->ReadRequest(*req)) return;
-        } catch (const ContentTooLargeError& e) {
-            LogDebug(
-                BCLog::HTTP,
-                "HTTP request body too large from client %s (id=%llu): %s",
-                client->m_origin,
-                client->m_id,
-                e.what());
+        client->m_req = std::make_unique<HTTPRequest>(client);
+    }
 
-            req->WriteReply(HTTP_CONTENT_TOO_LARGE);
-            client->m_disconnect = true;
-            return;
-        } catch (const std::runtime_error& e) {
-            LogDebug(
-                BCLog::HTTP,
-                "Error reading HTTP request from client %s (id=%llu): %s",
-                client->m_origin,
-                client->m_id,
-                e.what());
-
-            // We failed to read a complete request from the buffer
-            req->WriteReply(HTTP_BAD_REQUEST);
-            client->m_disconnect = true;
-            return;
-        }
-
-        // We read a complete request from the buffer into the queue
+    // Read data from the buffer into the current request
+    try {
+        client->ReadRequest(*client->m_req);
+    } catch (const ContentTooLargeError& e) {
         LogDebug(
             BCLog::HTTP,
-            "Received a %s request for %s from %s (id=%llu)",
-            RequestMethodString(req->m_method),
-            req->m_target,
+            "HTTP request body too large from client %s (id=%llu): %s",
             client->m_origin,
-            client->m_id);
+            client->m_id,
+            e.what());
 
-        // Move request to client
-        client->m_req = std::move(req);
+        client->m_req->SetState(HTTPRequest::State::Error);
+        client->m_req->WriteReply(HTTP_CONTENT_TOO_LARGE);
+        client->m_disconnect = true;
+        return;
+    } catch (const std::runtime_error& e) {
+        LogDebug(
+            BCLog::HTTP,
+            "Error reading HTTP request from client %s (id=%llu): %s",
+            client->m_origin,
+            client->m_id,
+            e.what());
+
+        // We failed to read a complete request from the buffer
+        client->m_req->SetState(HTTPRequest::State::Error);
+        client->m_req->WriteReply(HTTP_BAD_REQUEST);
+        client->m_disconnect = true;
+        return;
     }
 
     // If we are already handling a request from
@@ -1033,8 +1029,16 @@ void HTTPServer::MaybeDispatchRequestsFromClient(const std::shared_ptr<HTTPRemot
     // loop iteration.
     if (client->m_req_busy) return;
 
-    // Otherwise, if there is a request ready to go, handle it.
-    if (client->m_req) {
+    // Otherwise, if the request is ready, hand it to a worker.
+    if (client->m_req->GetState() == HTTPRequest::State::Complete) {
+        LogDebug(
+            BCLog::HTTP,
+            "Received a %s request for %s from %s (id=%llu)",
+            RequestMethodString(client->m_req->m_method),
+            client->m_req->m_target,
+            client->m_origin,
+            client->m_id);
+
         LOCK(m_request_dispatcher_mutex);
         client->m_req_busy = true;
         m_request_dispatcher(std::move(client->m_req));
@@ -1088,6 +1092,12 @@ void HTTPServer::DisconnectClients()
                                                  "Disconnecting HTTP client %s (id=%llu)",
                                                  client->m_origin,
                                                  client->m_id);
+
+                                        // HTTPRequest holds a shared_ptr back to its HTTPRemoteClient
+                                        // to keep the client alive from a worker thread. If an
+                                        // HTTPRequest is still in progress and hasn't been moved yet,
+                                        // it needs to be deleted now or the socket will be kept open.
+                                        client->m_req.reset();
                                         return true;
                                     });
     if (erased > 0) {
@@ -1105,13 +1115,34 @@ void HTTPServer::ClearConnectedClients()
     m_connected.clear();
 }
 
-bool HTTPRemoteClient::ReadRequest(HTTPRequest& req)
+void HTTPRemoteClient::ReadRequest(HTTPRequest& req)
 {
+    if (m_recv_buffer.empty()) return;
+
     LineReader reader(m_recv_buffer, MAX_HEADERS_SIZE);
 
-    if (!req.LoadControlData(reader)) return false;
-    if (!req.LoadHeaders(reader)) return false;
-    if (!req.LoadBody(reader)) return false;
+    switch(req.GetState()) {
+    case HTTPRequest::State::Init:
+        if (!req.LoadControlData(reader)) break;
+        req.SetState(HTTPRequest::State::NeedsHeaders);
+        [[fallthrough]];
+
+    case HTTPRequest::State::NeedsHeaders:
+        if (!req.LoadHeaders(reader)) break;
+        req.SetState(HTTPRequest::State::NeedsBody);
+        [[fallthrough]];
+
+    case HTTPRequest::State::NeedsBody:
+        if (!req.LoadBody(reader)) break;
+        req.SetState(HTTPRequest::State::Complete);
+        [[fallthrough]];
+
+    case HTTPRequest::State::Complete:
+        break;
+
+    case HTTPRequest::State::Error:
+        break;
+    }
 
     // Remove the bytes read out of the buffer.
     // If one of the above calls throws an error, the caller must
@@ -1119,8 +1150,6 @@ bool HTTPRemoteClient::ReadRequest(HTTPRequest& req)
     m_recv_buffer.erase(
         m_recv_buffer.begin(),
         m_recv_buffer.begin() + reader.Consumed());
-
-    return true;
 }
 
 bool HTTPRemoteClient::MaybeSendBytesFromBuffer()

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -464,10 +464,9 @@ public:
     std::vector<std::byte> m_recv_buffer{};
 
     //! Requests from a client must be processed in the order in which
-    //! they were received, blocking on a per-client basis. We won't
-    //! process the next request in the queue if we are currently busy
-    //! handling a previous request.
-    std::deque<std::unique_ptr<HTTPRequest>> m_req_queue;
+    //! they were received, blocking on a per-client basis. We read
+    //! one request at a time from the socket buffer then pass it to a worker.
+    std::unique_ptr<HTTPRequest> m_req;
 
     //! Set to true by the I/O thread when a request is popped off
     //! and passed to a worker thread, reset to false by the worker thread.

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -195,6 +195,24 @@ public:
     std::pair<bool, std::string> GetHeader(std::string_view hdr) const;
     std::string ReadBody() const { return m_body; }
     void WriteHeader(std::string&& hdr, std::string&& value);
+
+    enum class State {
+        Init,
+        NeedsHeaders,
+        NeedsBody,
+        Complete,
+        Error
+    };
+    State GetState() const { return m_state; }
+    void SetState(State state) { m_state = state; }
+
+    // If a large request is sent with "Transfer-encoding: chunked" we may
+    // read the chunk size in a separate I/O loop iteration than the chunk
+    // of data itself. Store the chunk size value here until the chunk is read.
+    std::optional<uint64_t> m_chunk_size;
+
+private:
+    State m_state = State::Init;
 };
 
 class HTTPServer
@@ -542,9 +560,9 @@ public:
     /**
      * Try to read an HTTP request from the receive buffer.
      * @param[in]   req     A HTTPRequest to read into
-     * @returns true upon reading a complete request, otherwise false (may throw).
+     * @throws std::runtime_error if request is unreadable or violates protocol
      */
-    bool ReadRequest(HTTPRequest& req);
+    void ReadRequest(HTTPRequest& req);
 
     /**
      * Push data (if there is any) from client's m_send_buffer to the connected socket.

--- a/test/functional/interface_http.py
+++ b/test/functional/interface_http.py
@@ -8,6 +8,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, str_to_b64str
 
 import http.client
+import socket
+import threading
 import time
 import urllib.parse
 
@@ -230,23 +232,37 @@ class HTTPBasicsTest (BitcoinTestFramework):
         assert_equal(response4.status, http.client.OK)
 
         conn = BitcoinHTTPConnection(self.node)
-        try:
-            # Excessive body size is invalid
-            conn.post_raw('/', f'{{"jsonrpc": "2.0", "id": "0", "method": "submitblock", "params": ["{"0" * bytes_above_limit}"]}}')
-            self.log.info("Client finished sending request before connection was terminated")
-        except NETWORK_ERRORS:
-            self.log.info("Client did not finish sending request before connection was terminated")
 
-        # The server will send a 413 response and disconnect but due to a race
-        # condition, the python client may or may not read the response before
-        # detecting the broken socket (which it may still be trying to write to).
+        # Split off the send into a background thread. When the server detects
+        # the excessive size it will stop reading from the socket, but the client
+        # will continue trying to write until the backpressure eventually
+        # drops the TCP window size to 0. While the send operation is blocking until
+        # it times out, we can still receive the server's reponse in the foreground.
+
+        def send_excessive_body(self, conn):
+            try:
+                # Excessive body size is invalid
+                conn.post_raw('/', f'{{"jsonrpc": "2.0", "id": "0", "method": "submitblock", "params": ["{"0" * bytes_above_limit}"]}}')
+                # On some platforms (e.g. Windows) the whole request may be
+                # accepted into the OS send buffer before the server disconnects.
+                # It's ok to allow that, the server-side behavior is asserted in
+                # the foreground thread via the 413 response.
+                self.log.info("Client finished sending request before connection was terminated")
+            except NETWORK_ERRORS:
+                self.log.info("Client did not finish sending request before connection was terminated")
+
+        send_thread = threading.Thread(target=send_excessive_body, args=(self, conn))
+        send_thread.start()
+
+        response5 = conn.recv_raw().decode()
+        assert "413 Content too large" in response5
+
         try:
-            response5 = conn.conn.getresponse()
-            assert_equal(response5.status, http.client.REQUEST_ENTITY_TOO_LARGE)
-            self.log.info(f"Client got expected response status {response5.status}")
-            assert conn.sock_closed()
-        except NETWORK_ERRORS:
-            self.log.info("Client did not read response before disconnecting")
+            conn.conn.sock.shutdown(socket.SHUT_RDWR)
+            self.log.info("Send thread force-closed by test framework")
+        except OSError:
+            self.log.info("Send thread was already closed by RST from server")
+        send_thread.join()
 
 
     def check_pipelining(self):
@@ -322,27 +338,41 @@ class HTTPBasicsTest (BitcoinTestFramework):
             b'3' * 10000000,
             b'"]}'
         ]
-        try:
-            conn.conn.request(
-                method='POST',
-                url='/',
-                body=iter(body_chunked),
-                headers=headers_chunked,
-                encode_chunked=True)
-            self.log.info("Client finished sending request before connection was terminated")
-        except NETWORK_ERRORS:
-            self.log.info("Client did not finish sending request before connection was terminated")
 
-        # The server will send a 413 response and disconnect but due to a race
-        # condition, the python client may or may not read the response before
-        # detecting the broken socket (which it may still be trying to write to).
+        # Split off the send into a background thread. When the server detects
+        # the excessive size it will stop reading from the socket, but the client
+        # will continue trying to write until the backpressure eventually
+        # drops the TCP window size to 0. While the send operation is blocking until
+        # it times out, we can still receive the server's reponse in the foreground.
+
+        def send_excessive_chunked(self, conn):
+            try:
+                conn.conn.request(
+                    method='POST',
+                    url='/',
+                    body=iter(body_chunked),
+                    headers=headers_chunked,
+                    encode_chunked=True)
+                # On some platforms (e.g. Windows) the whole request may be
+                # accepted into the OS send buffer before the server disconnects.
+                # It's ok to allow that, the server-side behavior is asserted in
+                # the foreground thread via the 413 response.
+                self.log.info("Client finished sending request before connection was terminated")
+            except NETWORK_ERRORS:
+                self.log.info("Client did not finish sending request before connection was terminated")
+
+        send_thread = threading.Thread(target=send_excessive_chunked, args=(self, conn))
+        send_thread.start()
+
+        response2 = conn.recv_raw().decode()
+        assert "413 Content too large" in response2
+
         try:
-            response2 = conn.conn.getresponse()
-            assert_equal(response2.status, http.client.REQUEST_ENTITY_TOO_LARGE)
-            self.log.info(f"Client got expected response status {response2.status}")
-            assert conn.sock_closed()
-        except NETWORK_ERRORS:
-            self.log.info("Client did not read response before disconnecting")
+            conn.conn.sock.shutdown(socket.SHUT_RDWR)
+            self.log.info("Send thread force-closed by test framework")
+        except OSError:
+            self.log.info("Send thread was already closed by RST from server")
+        send_thread.join()
 
 
     def check_idle_timeout(self):


### PR DESCRIPTION
This PR reduces the memory consumption of the HTTP Server when reading data from connected clients, and improves performance especially when requests are large (i.e. requiring multiple TCP packets).

In https://github.com/bitcoin/bitcoin/pull/35182 the server copies as much data as it can from the socket into application memory, and then tries to parse as many complete HTTP requests as possible from that data. If a request is discovered to be incomplete, the in-progress request is abandoned. The server tries again on the next I/O cycle to read the same data from the buffer, duplicating work as many times as it takes before the client finishes sending the request (or times out).

This PR implements two improvements to this:
1. Only parse one request at a time from the receive buffer. The server processes requests from each client in series anyway.
2. Add state to `HTTPRequest` so it can be filled with data from the receive buffer over multiple I/O loop iterations without losing progress.

If a client sends large or multiple requests, that data will sit in the kernel's socket buffer instead of the application memory. Eventually the socket buffer will fill up and TCP backpressure will kick in, dropping the TCP window to 0 and blocking the client from sending any more.

A state machine for `HTTPRemoteClient` was [discussed previously](https://github.com/bitcoin/bitcoin/pull/35182#pullrequestreview-4322490068) to control resource consumption. Another nice benefit of this model (for a follow-up PR) will be to insert the RPC authentication check after reading 8kB-limited headers but before the 32MB-limited request body.